### PR TITLE
Fix response generated when sign up validation fails

### DIFF
--- a/server/src/v1/middleware/Validators.js
+++ b/server/src/v1/middleware/Validators.js
@@ -6,7 +6,7 @@ class Validators {
     if (error) {
       return res.status(400).json({
         status: 400,
-        error: error.details,
+        error: error.details[0].message,
       });
     }
     next();


### PR DESCRIPTION
#### What does this PR do?
- Fix error in the response object generated when sign up validation fails

#### Description of Task to be completed
- When sign up validation fails the value of the error key is expected to be a string. Before refactoring the codebase the value of error key was an array.

#### How should this be manually tested?
- On Postman, make a request ``POST localhost:8001/api/auth/signup``
- Then send json payload:
```
{
       "firstName" :  "",
        "lastName": "Bar",
       " emai"l: "foo@bar.com",
        "password": "0000a"
}
```
- In the response object the value of the error key is expected to be an array.


#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
[#169771867](https://www.pivotaltracker.com/n/projects/2382168)

#### Screenshots (if appropriate)
- N/A